### PR TITLE
Add default workflow option

### DIFF
--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -174,6 +174,13 @@ parser.add_argument(
     """,
 )
 
+parser.add_argument(
+    "--default-workflow",
+    type=str,
+    default=None,
+    help="Path to a workflow JSON file to load automatically when a client connects.",
+)
+
 def is_valid_directory(path: str) -> str:
     """Validate if the given path is a directory, and check permissions."""
     if not os.path.exists(path):

--- a/server.py
+++ b/server.py
@@ -207,6 +207,7 @@ class PromptServer():
             try:
                 # Send initial state to the new client
                 await self.send("status", { "status": self.get_queue_info(), 'sid': sid }, sid)
+                await self.send_default_workflow(sid)
                 # On reconnect if we are the currently executing client send the current node
                 if self.client_id == sid and self.last_node_id is not None:
                     await self.send("executing", { "node": self.last_node_id }, sid)
@@ -749,6 +750,16 @@ class PromptServer():
         self.app.add_routes([
             web.static('/', self.web_root),
         ])
+
+    async def send_default_workflow(self, sid):
+        if args.default_workflow is None:
+            return
+        try:
+            with open(args.default_workflow, "r", encoding="utf-8") as f:
+                workflow = json.load(f)
+            await self.send("loadWorkflow", workflow, sid)
+        except Exception as e:
+            logging.error(f"Failed to send default workflow: {e}")
 
     def get_queue_info(self):
         prompt_info = {}


### PR DESCRIPTION
## Summary
- allow customizing the workflow loaded at startup via `--default-workflow`
- send the workflow to clients when they connect

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*