### PR TITLE
Add default workflow loading option

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,12 @@ For models compatible with Cambricon Extension for PyTorch (torch_mlu). Here's a
 
 ```python main.py```
 
+To open a workflow automatically when a client connects, launch ComfyUI with:
+
+```bash
+python main.py --default-workflow path/to/workflow.json
+```
+
 ### For AMD cards not officially supported by ROCm
 
 Try running it with this command if you have issues:

--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -174,6 +174,13 @@ parser.add_argument(
     """,
 )
 
+parser.add_argument(
+    "--default-workflow",
+    type=str,
+    default=None,
+    help="Path to a workflow JSON file to load automatically when a client connects.",
+)
+
 def is_valid_directory(path: str) -> str:
     """Validate if the given path is a directory, and check permissions."""
     if not os.path.exists(path):

--- a/server.py
+++ b/server.py
@@ -207,6 +207,7 @@ class PromptServer():
             try:
                 # Send initial state to the new client
                 await self.send("status", { "status": self.get_queue_info(), 'sid': sid }, sid)
+                await self.send_default_workflow(sid)
                 # On reconnect if we are the currently executing client send the current node
                 if self.client_id == sid and self.last_node_id is not None:
                     await self.send("executing", { "node": self.last_node_id }, sid)
@@ -749,6 +750,16 @@ class PromptServer():
         self.app.add_routes([
             web.static('/', self.web_root),
         ])
+
+    async def send_default_workflow(self, sid):
+        if args.default_workflow is None:
+            return
+        try:
+            with open(args.default_workflow, "r", encoding="utf-8") as f:
+                workflow = json.load(f)
+            await self.send("loadWorkflow", workflow, sid)
+        except Exception as e:
+            logging.error(f"Failed to send default workflow: {e}")
 
     def get_queue_info(self):
         prompt_info = {}


### PR DESCRIPTION
## Summary
- add a `--default-workflow` CLI argument in `comfy/cli_args.py`
- load the default workflow and send it to clients in `server.py`
- document `--default-workflow` usage in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*